### PR TITLE
fix: improve error handling and organization name handling

### DIFF
--- a/.github/workflows/ai-pr-org-metrics.yml
+++ b/.github/workflows/ai-pr-org-metrics.yml
@@ -44,7 +44,7 @@ jobs:
         id: counts
         env:
           GH_TOKEN: ${{ secrets.METRICS_TOKEN }}  # GitHub APIの認証トークン
-          ORG: MyOrg                              # 対象のGitHub組織名
+          ORG: ${{ github.repository_owner }}      # リポジトリのオーナーを組織名として使用
           AI_LABELS: ${{ github.event.inputs.ai_labels || 'ai,ai-generated,ai-assist' }}  # AI関連PRのラベル
         run: |
           # エラーハンドリング用の関数
@@ -108,8 +108,13 @@ jobs:
           }
 
           # 組織内のリポジトリ一覧を取得
+          echo "Fetching repositories for organization: $ORG"
           repos_response=$(make_api_request "https://api.github.com/orgs/$ORG/repos?per_page=100")
           repos=$(echo "$repos_response" | jq -r '.[].name')
+          
+          if [ -z "$repos" ]; then
+            handle_error "No repositories found for organization: $ORG"
+          fi
 
           # リポジトリごとの結果を格納する配列
           declare -A repo_ai_counts
@@ -119,6 +124,8 @@ jobs:
 
           # 各リポジトリのPR数を取得
           for repo in $repos; do
+            echo "Processing repository: $repo"
+            
             # AIラベルが付いたマージ済みPRの数を取得
             ai_response=$(make_api_request "https://api.github.com/search/issues?q=repo:$ORG/$repo+is:pr+is:merged+($label_query)+merged:$start..$end")
             ai_count=$(echo "$ai_response" | jq -r '.total_count')


### PR DESCRIPTION
   ## 変更内容
   - AI関連PRの比率を計算するGitHub Actionsワークフローを追加
   - 組織内の全リポジトリのAI PR比率を週次で計算
   - リポジトリごとの詳細なメトリクスを提供
   - 手動実行時の日付範囲指定に対応
   - エラーハンドリングとログ出力を改善

   ## 主な機能
   - 毎週月曜日の0:00 UTC（日本時間9:00）に自動実行
   - 手動実行時に日付範囲とAIラベルを指定可能
   - 組織全体とリポジトリごとのAI PR比率を計算
   - 結果をGitHub Actionsのサマリーに出力

   ## 設定が必要な項目
   - `METRICS_TOKEN`: GitHub APIの認証トークン（Personal Access Token）
   - スコープ: `repo` と `read:org`